### PR TITLE
small refactor

### DIFF
--- a/lib/earrrl/limiter.rb
+++ b/lib/earrrl/limiter.rb
@@ -4,7 +4,7 @@ module Earrrl
   class Limiter
     class ScriptNotLoadedError < StandardError; end
 
-    def self.load_script(redis)
+    def self.script_token(redis)
       if !defined? @script_token
         self.load_script!(redis)
       end
@@ -46,7 +46,7 @@ module Earrrl
       rate = nil
 
       begin
-        rate = @redis.evalsha(self.class.load_script(@redis),["#{@prefix}:#{key}"], [@epsilon, amount])
+        rate = @redis.evalsha(self.class.script_token(@redis), ["#{@prefix}:#{key}"], [@epsilon, amount])
       rescue Redis::CommandError => e
         if e.message =~ /NOSCRIPT/
           rate = @redis.evalsha(self.class.load_script!(@redis), ["#{@prefix}:#{key}"], [@epsilon, amount])

--- a/lib/earrrl/script_loader.rb
+++ b/lib/earrrl/script_loader.rb
@@ -2,6 +2,9 @@
 
 
 module Earrrl
+
+
+
   class ScriptLoader
 
     EARRRL_SCRIPT = <<~LUA
@@ -40,7 +43,7 @@ module Earrrl
     LUA
 
     def self.load(redis_instance)
-      Earrrl::Limiter.set_script_token(redis_instance.script "load", EARRRL_SCRIPT)
+      redis_instance.script "load", EARRRL_SCRIPT
     end
 
   end

--- a/lib/earrrl/script_loader.rb
+++ b/lib/earrrl/script_loader.rb
@@ -2,9 +2,6 @@
 
 
 module Earrrl
-
-
-
   class ScriptLoader
 
     EARRRL_SCRIPT = <<~LUA


### PR DESCRIPTION
Luke noticed that the limiter called the script_loader and also that the script_loader called the limiter. So this was a small refactor so that all dependencies form a DAG.

* replaces the `{set|get}_script_token` with `load_script` and `load_script!` - though another option here would be to have a single `load_script` class method that takes an optional parameter to uncache or something.
* `script_loader.load` just returns the SHA rather than setting it on the limiter
* removed `ScriptNotLoadedError` - no longer required